### PR TITLE
Add admonition about CIVS invalid domains

### DIFF
--- a/doc/email.md
+++ b/doc/email.md
@@ -6,6 +6,9 @@ you won't be able to [vote](./vote.md).
 Be aware of the [the timeline](../README.md#timeline):
 The deadline for changing emails is Sunday 2024-10-06.
 
+> [!Warning]
+> The CIVS platform does not accept all valid domains, and will throw an *"Illegal mail address"* error for some. Be sure to check **early** whether your email address is accepted by the platform, and to submit a PR updating `voters.json` if necessary.
+
 To check if the email is set and correct:
 1. Get your GitHub ID, e.g. using
    ```sh


### PR DESCRIPTION
When trying to activate my email on the [CIVS](https://civs1.civs.us/cgi-bin/opt_in.pl) voting platform, I received the error "Illegal mail address". I tested with a few [other domains](https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains), and found that the site simply won't accept several valid ones.

This PR updates the README with an admonition warning about this possibility.

<img width="521" alt="illegal-mail-address" src="https://github.com/user-attachments/assets/c568ab35-927f-445c-9937-22959fe55352">