### PR TITLE
voters.json: set @paparodeo email

### DIFF
--- a/voters.json
+++ b/voters.json
@@ -841,5 +841,5 @@
   "git@meppu.boo": 112294217,
   "nixpkgs-commits@deshaw.com": 130508846,
   "@arthsmn: No known email, you cannot vote unless one is added with a PR!": 150680976,
-  "@paparodeo: email should be paparodeo@proton.me but checking": 170618376
+  "paparodeo@proton.me": 170618376
 }


### PR DESCRIPTION
@paparodeo your account is unambiguously verified as the current account of an automatically eligible voter; I think you have an invitation to the organisation / voters team, and any positive reaction on this PR from you (approval or comment with agreement or :+1: reaction) will be treated as confitmation from you that the email specified is also yours.