### PR TITLE
voters.json: Update nicoo's email address

### DIFF
--- a/voters.json
+++ b/voters.json
@@ -298,7 +298,7 @@
   "scottworley@scottworley.com": 1118859,
   "edolstra+nixpkgs@gmail.com": 1148549,
   "s.vanderburg@tudelft.nl": 1153271,
-  "nicoo@debian.org": 1155801,
+  "nicoo@mur.at": 1155801,
   "ryan@trinkle.org": 1156448,
   "brian@41north.dev": 1173648,
   "ab@fmap.me": 1174810,


### PR DESCRIPTION
`nicoo@debian.org` redirects to a domain whose mail server is currently down.